### PR TITLE
Fix launch on Pixel 3a with cyannogen 12

### DIFF
--- a/MockGPS/app/src/main/java/com/navigine/mockgps/MockLocationImpl.java
+++ b/MockGPS/app/src/main/java/com/navigine/mockgps/MockLocationImpl.java
@@ -1,6 +1,7 @@
 package com.navigine.mockgps;
 
 import android.content.Context;
+import android.location.Criteria;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Build;
@@ -48,8 +49,8 @@ public class MockLocationImpl {
                 false,
                 true,
                 true,
-                0,
-                5);
+                Criteria.POWER_LOW,
+                Criteria.ACCURACY_LOW);
 
         Location newLocation = new Location(provider);
 


### PR DESCRIPTION
**Changes**
I am using Cyannogen mod on my debug android device. Looking for a mock location open source app I noticed your repo. But it wasn't been working well till because values for accuracy and power level in test location provider hadn't been fitting required intervals. After changing them to new ones the app launched successfully.

**Testing performed**
Launched app on my Pixel 3a, successfully mocked location in Vienna.
![photo_2022-11-24 15 52 34](https://user-images.githubusercontent.com/21157170/203789682-45274207-71e1-4989-998a-1476eb75fb4d.jpeg)

